### PR TITLE
only build on push

### DIFF
--- a/.github/workflows/build_dev.yaml
+++ b/.github/workflows/build_dev.yaml
@@ -47,7 +47,7 @@ jobs:
         with:
           context: .
           file: ./backend/Dockerfile
-          push: true
+          push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
@@ -86,7 +86,7 @@ jobs:
         with:
           context: .
           file: ./frontend/Dockerfile
-          push: true
+          push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
@@ -128,7 +128,7 @@ jobs:
         with:
           context: .
           file: ./nginx/Dockerfile
-          push: true
+          push: ${{ github.event_name == 'push' }}
           build-args: |
             build_env=${{ env.ENVIRONMENT }}
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/build_dev.yaml` file to conditionally push Docker images based on the event type. The most important changes are:

Updates to Docker image pushing logic:

* [`.github/workflows/build_dev.yaml`](diffhunk://#diff-bca8d55204cc8e59f941aa46426ab94cdd4c5348f6e122309a6b8ef71a4069fcL50-R50): Modified the `push` parameter to use a conditional expression `${{ github.event_name == 'push' }}` for the backend Dockerfile.
* [`.github/workflows/build_dev.yaml`](diffhunk://#diff-bca8d55204cc8e59f941aa46426ab94cdd4c5348f6e122309a6b8ef71a4069fcL89-R89): Modified the `push` parameter to use a conditional expression `${{ github.event_name == 'push' }}` for the frontend Dockerfile.
* [`.github/workflows/build_dev.yaml`](diffhunk://#diff-bca8d55204cc8e59f941aa46426ab94cdd4c5348f6e122309a6b8ef71a4069fcL131-R131): Modified the `push` parameter to use a conditional expression `${{ github.event_name == 'push' }}` for the nginx Dockerfile.