### PR TITLE
install certbot to nginx container

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -10,4 +10,9 @@ COPY ./nginx/sites-available/ /etc/nginx/conf.d/
 
 COPY --from=frontend_image /usr/share/nginx/html/ /usr/share/nginx/html/
 
+# Install Certbot
+RUN apk add --no-cache certbot certbot-nginx
+
+RUN mkdir -p /var/www/certbot
+
 LABEL org.opencontainers.image.source=https://github.com/Ygg-Drasill/PenaltyThing


### PR DESCRIPTION
This pull request includes a small but important change to the `nginx/Dockerfile` to enhance the security and functionality of the Nginx server by adding Certbot for SSL certificate management.

## Changes to Nginx Dockerfile:

* Added installation of Certbot and Certbot-Nginx to manage SSL certificates (`nginx/Dockerfile`).
* Created a directory for Certbot to store its files (`nginx/Dockerfile`).